### PR TITLE
Added setting of ActivationFunction into cloned FeedforwardLayer during FeedforwardNetwork#cloneStructure()

### DIFF
--- a/JavaIntroNeuralNetworkEdition2/src/com/heatonresearch/book/introneuralnet/neural/feedforward/FeedforwardNetwork.java
+++ b/JavaIntroNeuralNetworkEdition2/src/com/heatonresearch/book/introneuralnet/neural/feedforward/FeedforwardNetwork.java
@@ -148,7 +148,7 @@ public class FeedforwardNetwork implements Serializable {
 		final FeedforwardNetwork result = new FeedforwardNetwork();
 
 		for (final FeedforwardLayer layer : this.layers) {
-			final FeedforwardLayer clonedLayer = new FeedforwardLayer(layer
+			final FeedforwardLayer clonedLayer = new FeedforwardLayer(layer.getActivationFunction(), layer
 					.getNeuronCount());
 			result.addLayer(clonedLayer);
 		}


### PR DESCRIPTION
Without this changes information about activation functions will be lost during FeedforwardNetwork#clone()
(and layers of cloned network will always have ActivationSigmoid function).
