### PR TITLE
Extra work - cost is being calculated twice

### DIFF
--- a/JavaIntroNeuralNetworkEdition2/src/com/heatonresearch/book/introneuralnet/neural/feedforward/train/genetic/TrainingSetNeuralChromosome.java
+++ b/JavaIntroNeuralNetworkEdition2/src/com/heatonresearch/book/introneuralnet/neural/feedforward/train/genetic/TrainingSetNeuralChromosome.java
@@ -73,8 +73,5 @@ public class TrainingSetNeuralChromosome extends
 
 		// copy the new genes
 		super.setGenes(list);
-
-		calculateCost();
-
 	}
 }


### PR DESCRIPTION
NeuralChromosome.setGenes() calls calculateCost() after updating the gene list. Override is redundant?
